### PR TITLE
Bug with llm_model

### DIFF
--- a/internal/clients/agents.go
+++ b/internal/clients/agents.go
@@ -172,7 +172,7 @@ func toAgent(a *entities.AgentModel, cs *state) (*agent, error) {
 		Uuid:           a.Id.ValueString(),
 		Name:           a.Name.ValueString(),
 		Image:          a.Image.ValueString(),
-		LlmModel:       a.Model.ValueString(),
+		LlmModel:       a.LlmModel.ValueString(),
 		Email:          a.Email.ValueString(),
 		Description:    a.Description.ValueString(),
 		AiInstructions: a.Instructions.ValueString(),


### PR DESCRIPTION
llm_model       = "azure/gpt-4-32k"

Error: Unsupported argument
│
│   on agents.tf line 12, in resource "kubiya_agent" "agent":
│   12:   llm_model       = "azure/gpt-4-32k"
│
│ An argument named "llm_model" is not expected here.