### PR TITLE
Add "ManagedBy" field to various client models

### DIFF
--- a/internal/clients/agents.go
+++ b/internal/clients/agents.go
@@ -20,10 +20,11 @@ type task struct {
 }
 
 type agent struct {
-	Name  string `json:"name"`
-	Uuid  string `json:"uuid"`
-	Email string `json:"email,omitempty"`
-	Image string `json:"image,omitempty"`
+	Name      string `json:"name"`
+	Uuid      string `json:"uuid"`
+	ManagedBy string `json:"managed_by"`
+	Email     string `json:"email,omitempty"`
+	Image     string `json:"image,omitempty"`
 
 	Links        []string  `json:"links"`
 	Tools        []string  `json:"tools"`
@@ -393,6 +394,7 @@ func (c *Client) CreateAgent(ctx context.Context, e *entities.AgentModel) (*enti
 		if err != nil {
 			return nil, err
 		}
+		data.ManagedBy = "terraform"
 
 		body, err := toJson(data)
 		if err != nil {

--- a/internal/clients/integration.go
+++ b/internal/clients/integration.go
@@ -27,6 +27,7 @@ type (
 		Name        string      `json:"name"`
 		Configs     []configApi `json:"configs"`
 		AuthType    string      `json:"auth_type"`
+		ManagedBy   string      `json:"managed_by"`
 		Description string      `json:"description"`
 		Type        string      `json:"integration_type"`
 	}
@@ -199,6 +200,7 @@ func (c *Client) CreateIntegration(ctx context.Context, e *entities.IntegrationM
 			return nil, err
 		}
 
+		data.ManagedBy = "terraform"
 		body, err := toJson(data)
 		if err != nil {
 			return nil, err

--- a/internal/clients/knowledge.go
+++ b/internal/clients/knowledge.go
@@ -24,6 +24,7 @@ type knowledge struct {
 	SupportedAgents       []string `json:"supported_agents"`
 	SupportedAgentsGroups []string `json:"supported_agents_groups"`
 	Id                    string   `json:"uuid"`
+	ManagedBy             string   `json:"managed_by"`
 }
 
 func toKnowledge(a *entities.KnowledgeModel, cs *state) (*knowledge, error) {
@@ -224,6 +225,7 @@ func (c *Client) CreateKnowledge(ctx context.Context, e *entities.KnowledgeModel
 			return nil, err
 		}
 
+		data.ManagedBy = "terraform"
 		body, err := toJson(data)
 		if err != nil {
 			return nil, err

--- a/internal/clients/webhook.go
+++ b/internal/clients/webhook.go
@@ -24,6 +24,7 @@ type (
 		CreatedBy     string         `json:"created_by"`
 		UpdatedAt     time.Time      `json:"updated_at"`
 		WebhookUrl    string         `json:"webhook_url"`
+		ManagedBy     string         `json:"managed_by"`
 		Communication *communication `json:"communication"`
 	}
 
@@ -221,7 +222,10 @@ func (c *Client) CreateWebhook(ctx context.Context, entity *entities.WebhookMode
 
 		uri := c.uri("/api/v1/event")
 
-		body, err := toJson(toWebhook(entity, cs))
+		data := toWebhook(entity, cs)
+		data.ManagedBy = "terraform"
+
+		body, err := toJson(data)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Updated the models for knowledge, integration, webhook, and agents to include the "ManagedBy" field. This field is set to "terraform" during data transformation before serialization.