### PR TITLE
Add "TaskId" and "ManagedBy" fields to client models

### DIFF
--- a/internal/clients/agents.go
+++ b/internal/clients/agents.go
@@ -22,6 +22,7 @@ type task struct {
 type agent struct {
 	Name      string `json:"name"`
 	Uuid      string `json:"uuid"`
+	TaskId    string `json:"task_id"`
 	ManagedBy string `json:"managed_by"`
 	Email     string `json:"email,omitempty"`
 	Image     string `json:"image,omitempty"`
@@ -394,7 +395,8 @@ func (c *Client) CreateAgent(ctx context.Context, e *entities.AgentModel) (*enti
 		if err != nil {
 			return nil, err
 		}
-		data.ManagedBy = "terraform"
+
+		data.ManagedBy, data.TaskId = managedBy()
 
 		body, err := toJson(data)
 		if err != nil {

--- a/internal/clients/helpers.go
+++ b/internal/clients/helpers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -131,4 +132,18 @@ func toStringMap(m types.Map) map[string]string {
 	}
 
 	return result
+}
+
+func managedBy() (string, string) {
+	const (
+		empty       = ""
+		byTask      = "task"
+		env         = "TASK_UUID"
+		byTerraform = "terraform"
+	)
+	if taskId := os.Getenv(env); len(taskId) >= 1 {
+		return taskId, byTask
+	}
+
+	return empty, byTerraform
 }

--- a/internal/clients/integration.go
+++ b/internal/clients/integration.go
@@ -27,6 +27,7 @@ type (
 		Name        string      `json:"name"`
 		Configs     []configApi `json:"configs"`
 		AuthType    string      `json:"auth_type"`
+		TaskId      string      `json:"task_id"`
 		ManagedBy   string      `json:"managed_by"`
 		Description string      `json:"description"`
 		Type        string      `json:"integration_type"`
@@ -200,7 +201,8 @@ func (c *Client) CreateIntegration(ctx context.Context, e *entities.IntegrationM
 			return nil, err
 		}
 
-		data.ManagedBy = "terraform"
+		data.ManagedBy, data.TaskId = managedBy()
+
 		body, err := toJson(data)
 		if err != nil {
 			return nil, err

--- a/internal/clients/knowledge.go
+++ b/internal/clients/knowledge.go
@@ -24,6 +24,7 @@ type knowledge struct {
 	SupportedAgents       []string `json:"supported_agents"`
 	SupportedAgentsGroups []string `json:"supported_agents_groups"`
 	Id                    string   `json:"uuid"`
+	TaskId                string   `json:"task_id"`
 	ManagedBy             string   `json:"managed_by"`
 }
 
@@ -225,7 +226,8 @@ func (c *Client) CreateKnowledge(ctx context.Context, e *entities.KnowledgeModel
 			return nil, err
 		}
 
-		data.ManagedBy = "terraform"
+		data.ManagedBy, data.TaskId = managedBy()
+
 		body, err := toJson(data)
 		if err != nil {
 			return nil, err

--- a/internal/clients/runners.go
+++ b/internal/clients/runners.go
@@ -11,10 +11,12 @@ import (
 )
 
 type runner struct {
-	Key     string `json:"key"`
-	Url     string `json:"url"`
-	Name    string `json:"name"`
-	Subject string `json:"subject"`
+	Key       string `json:"key"`
+	Url       string `json:"url"`
+	Name      string `json:"name"`
+	Subject   string `json:"subject"`
+	TaskId    string `json:"task_id"`
+	ManagedBy string `json:"managed_by"`
 }
 
 func (c *Client) ReadRunner(ctx context.Context, entity *entities.RunnerModel) error {
@@ -72,7 +74,17 @@ func (c *Client) CreateRunner(ctx context.Context, entity *entities.RunnerModel)
 		path := entity.Path.ValueString()
 		name := entity.Name.ValueString()
 
-		resp, err := c.create(ctx, c.uri(format(uri, name)), nil)
+		data := &runner{}
+		data.ManagedBy, data.TaskId = managedBy()
+
+		body, err := toJson(data)
+		if err != nil {
+			return nil, err
+		}
+
+		reqUri := c.uri(format(uri, name))
+
+		resp, err := c.create(ctx, reqUri, body)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/clients/webhook.go
+++ b/internal/clients/webhook.go
@@ -24,6 +24,7 @@ type (
 		CreatedBy     string         `json:"created_by"`
 		UpdatedAt     time.Time      `json:"updated_at"`
 		WebhookUrl    string         `json:"webhook_url"`
+		TaskId        string         `json:"task_id"`
 		ManagedBy     string         `json:"managed_by"`
 		Communication *communication `json:"communication"`
 	}
@@ -223,7 +224,7 @@ func (c *Client) CreateWebhook(ctx context.Context, entity *entities.WebhookMode
 		uri := c.uri("/api/v1/event")
 
 		data := toWebhook(entity, cs)
-		data.ManagedBy = "terraform"
+		data.ManagedBy, data.TaskId = managedBy()
 
 		body, err := toJson(data)
 		if err != nil {


### PR DESCRIPTION
Updated the models for knowledge, integration, runners, webhook, and agents to include the "TaskId" and "ManagedBy" fields. "TaskId" is derived from environment variables, while "ManagedBy" indicates whether the item is managed by "terraform" or a task.