### PR TITLE
Add Kubernetes integration to clients list

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -317,6 +317,7 @@ func (c *Client) integrations() ([]*integration, error) {
 
 	result := []*integration{
 		{Name: "slack"},
+		{Name: "kubernetes"},
 	}
 
 	if val, ok := tmp[managed]; ok {


### PR DESCRIPTION
Introduced Kubernetes as a supported integration in the client package. This change ensures Kubernetes appears in the list of available integrations alongside existing services like Slack.