### PR TITLE
Refactor jsonStringModifier to use pointer receiver.

### DIFF
--- a/internal/entities/modifiers.go
+++ b/internal/entities/modifiers.go
@@ -37,8 +37,8 @@ func (j *jsonStringModifier) PlanModifyString(_ context.Context, req planmodifie
 	err := json.Unmarshal([]byte(planValue), &tmp)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"json unmarshal error",
-			err.Error(),
+			"Error parsing JSON",
+			"Failed to parse JSON string: "+err.Error(),
 		)
 		return
 	}
@@ -46,8 +46,8 @@ func (j *jsonStringModifier) PlanModifyString(_ context.Context, req planmodifie
 	planResult, err := json.Marshal(tmp)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"json marshal error",
-			err.Error(),
+			"Error normalizing JSON",
+			"Failed to normalize JSON: "+err.Error(),
 		)
 		return
 	}

--- a/internal/entities/modifiers.go
+++ b/internal/entities/modifiers.go
@@ -8,27 +8,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ planmodifier.String = jsonStringModifier{}
+var (
+	_ planmodifier.String = &jsonStringModifier{}
+)
 
 type jsonStringModifier struct{}
 
-func (j jsonStringModifier) Description(_ context.Context) string {
+func jsonNormalizationModifier() planmodifier.String {
+	modifier := &jsonStringModifier{}
+	return modifier
+}
+
+func (j *jsonStringModifier) Description(_ context.Context) string {
 	return "modify json string"
 }
 
-func (j jsonStringModifier) MarkdownDescription(_ context.Context) string {
+func (j *jsonStringModifier) MarkdownDescription(_ context.Context) string {
 	return "modify json string"
 }
 
-func (j jsonStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if req.StateValue.IsNull() {
-		return
-	}
-
-	if req.PlanValue.IsUnknown() {
-		return
-	}
-
+func (j *jsonStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
 		return
 	}

--- a/internal/entities/modifiers.go
+++ b/internal/entities/modifiers.go
@@ -20,11 +20,11 @@ func jsonNormalizationModifier() planmodifier.String {
 }
 
 func (j *jsonStringModifier) Description(_ context.Context) string {
-	return "modify json string"
+	return "Normalizes JSON string format for consistent comparison"
 }
 
 func (j *jsonStringModifier) MarkdownDescription(_ context.Context) string {
-	return "modify json string"
+	return "Normalizes JSON string format for consistent comparison"
 }
 
 func (j *jsonStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {

--- a/internal/entities/modifiers.go
+++ b/internal/entities/modifiers.go
@@ -28,7 +28,7 @@ func (j *jsonStringModifier) MarkdownDescription(_ context.Context) string {
 }
 
 func (j *jsonStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 

--- a/internal/entities/source.go
+++ b/internal/entities/source.go
@@ -42,7 +42,7 @@ func SourceSchema() schema.Schema {
 				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
-					jsonStringModifier{},
+					jsonNormalizationModifier(),
 				},
 				Description:         "The dynamic configuration of the source",
 				MarkdownDescription: "A map of key-value pairs representing dynamic configuration for the source",


### PR DESCRIPTION
Updated jsonStringModifier to use a pointer receiver for implementing the plan modifier.String interface. Introduced a new factory function, jsonNormalizationModifier, to ensure proper instantiation of the modifier. Adjustments were made to reflect these changes where the modifier is used.