### PR TITLE
Handle nil DynamicConfig in returnSource initialization

### DIFF
--- a/internal/clients/source.go
+++ b/internal/clients/source.go
@@ -131,6 +131,10 @@ func (c *Client) CreateSource(ctx context.Context, e *entities.SourceModel) (*en
 			return nil, err
 		}
 
+		if result.DynamicConfig == nil {
+			returnSource.DynamicConfig = types.StringValue(e.DynamicConfig.ValueString())
+		}
+
 		return returnSource, nil
 	}
 


### PR DESCRIPTION
Added a check to ensure DynamicConfig is properly assigned when it is nil in result. This prevents potential nil pointer issues and ensures consistent initialization of returnSource.