### PR TITLE
Add CreatedBy field to webhook client initialization

### DIFF
--- a/internal/clients/webhook.go
+++ b/internal/clients/webhook.go
@@ -43,6 +43,7 @@ func toWebhook(w *entities.WebhookModel, cs *state) *webhook {
 		Filter:     w.Filter.ValueString(),
 		Prompt:     w.Prompt.ValueString(),
 		Source:     w.Source.ValueString(),
+		CreatedBy:  w.CreatedBy.ValueString(),
 	}
 
 	for _, a := range cs.agentList {


### PR DESCRIPTION
Include the `CreatedBy` field in the webhook client struct to capture the creator metadata. This ensures completeness and consistency in tracking webhook configurations.